### PR TITLE
Make paths absolute

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ getApiList()
 				subtitle: `${x.barrel} - ${x.docType}`,
 				arg: url,
 				quicklookurl: url,
-				icon: TYPES.indexOf(x.docType) !== -1 && {path: `./icons/${x.docType}.png`},
+				icon: TYPES.indexOf(x.docType) !== -1 && {path: `${__dirname}/icons/${x.docType}.png`},
 				mods: {
 					alt: {
 						subtitle: x.stability


### PR DESCRIPTION
Hi,

This PR updates the icon paths to be absolute which makes it compatible for my [app](https://github.com/vutran/dext).
